### PR TITLE
fix potential nil reference

### DIFF
--- a/prototypes/compat/recycling-final-fixes.lua
+++ b/prototypes/compat/recycling-final-fixes.lua
@@ -12,7 +12,7 @@ if mods["quality"] then
         local result_scalar = wood_ratios[result.name]
         if result_scalar then
           result.name = "woodchips"
-          local amount = result_scalar * (result.amount - result.amount % 1 + result.extra_count_fraction)
+          local amount = result_scalar * (result.amount - result.amount % 1 + (result.extra_count_fraction or 0.0))
           result.amount = amount
           result.extra_count_fraction = amount % 1
         end


### PR DESCRIPTION
result.extra_count_fraction is potentially nil when custom recycling recipes are set.
idk if a default of 0 is the best num, but now it wont crash on startup